### PR TITLE
Linked-list find and handling functions with return values

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -20,6 +20,7 @@ src/Examples/KVStore/KVStore.v
 src/Examples/KVStore/Manual.v
 src/Examples/KVStore/Properties.v
 src/Examples/KVStore/Tactics.v
+src/Examples/LinkedList/Find.v
 src/Examples/LinkedList/LinkedList.v
 src/Examples/Swap/Properties.v
 src/Examples/Swap/Swap.v

--- a/src/Examples/Cells/Cells.v
+++ b/src/Examples/Cells/Cells.v
@@ -5,12 +5,19 @@ Section with_semantics.
           {semantics_ok : Semantics.parameters_ok semantics}.
   Record cell := { data : Semantics.word }.
 
-  Definition cell_value (addr: address) (c: cell) : Semantics.mem -> Prop :=
+  Definition cell_value (addr: address) (c: cell)
+    : Semantics.mem -> Prop :=
     scalar addr c.(data).
 
-  Definition TwoCells a_ptr b_ptr ab : Semantics.mem -> Prop :=
-    sep (cell_value a_ptr (fst ab)) (cell_value b_ptr (snd ab)).
+  Definition OneCell c_ptr c
+    : list word -> Semantics.mem -> Prop :=
+    fun _ => cell_value c_ptr c.
+  Hint Unfold OneCell : compiler.
 
+  Definition TwoCells a_ptr b_ptr ab
+    : list word -> Semantics.mem -> Prop :=
+    fun _ =>
+      sep (cell_value a_ptr (fst ab)) (cell_value b_ptr (snd ab)).
   Hint Unfold TwoCells : compiler.
 
   Definition get c := c.(data).
@@ -19,7 +26,8 @@ Section with_semantics.
   Lemma compile_get :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-           tr R R' functions T (pred: T -> _ -> Prop)
+           tr retvars R R' functions
+           T (pred: T -> list word -> Semantics.mem -> Prop)
            c c_ptr c_var k k_impl,
     forall var,
       sep (cell_value c_ptr c) R' mem ->
@@ -28,6 +36,7 @@ Section with_semantics.
       (let head := v in
        find k_impl
        implementing (pred (k head))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals (map.put locals var head)
        and-memory mem and-trace tr and-rest R
@@ -36,6 +45,7 @@ Section with_semantics.
        find (cmd.seq (cmd.set var (expr.load access_size.word (expr.var c_var)))
                      k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -59,7 +69,8 @@ Section with_semantics.
   Lemma compile_put :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-           tr R R' functions T (pred: T -> _ -> Prop)
+           tr retvars R R' functions
+           T (pred: T -> list word -> _ -> Prop)
            c c_ptr c_var x x_var k k_impl,
       sep (cell_value c_ptr c) R' mem ->
       map.get locals c_var = Some c_ptr ->
@@ -70,6 +81,7 @@ Section with_semantics.
          sep (cell_value c_ptr head) R' m ->
          (find k_impl
           implementing (pred (k head))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals
           and-memory m and-trace tr and-rest R
@@ -78,6 +90,7 @@ Section with_semantics.
        find (cmd.seq (cmd.store access_size.word (expr.var c_var) (expr.var x_var))
                      k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -98,7 +111,7 @@ Section with_semantics.
       eassumption. }
   Qed.
 End with_semantics.
-Hint Unfold TwoCells : compiler.
+Hint Unfold OneCell TwoCells : compiler.
 
 Ltac cell_compile_step :=
   gen_sym_inc;

--- a/src/Examples/Cells/Incr.v
+++ b/src/Examples/Cells/Incr.v
@@ -19,7 +19,7 @@ Section with_semantics.
           ===>
           "incr" @ [c_ptr]
           ===>
-          (c_ptr ~> (incr_gallina_spec c))).
+          (OneCell c_ptr (incr_gallina_spec c))).
 
   Derive body SuchThat
          (let incr := ("incr", (["c_ptr"], [], body)) in
@@ -30,7 +30,7 @@ Section with_semantics.
                    exact x)))
          As body_correct.
   Proof.
-    cbv [spec_of_incr program_logic_goal_for].
+    cbv [spec_of_incr].
     compile.
   Qed.
 

--- a/src/Examples/Cells/Swap.v
+++ b/src/Examples/Cells/Swap.v
@@ -17,7 +17,7 @@ Derive swap_body SuchThat
         program_logic_goal_for swap
         (forall functions,
          forall a_ptr a b_ptr b tr R mem,
-           sep (TwoCells a_ptr b_ptr (a,b)) R mem ->
+           sep (TwoCells a_ptr b_ptr (a,b) []) R mem ->
            WeakestPrecondition.call
              (swap :: functions)
              "swap"

--- a/src/Examples/ECC/CondSwap.v
+++ b/src/Examples/ECC/CondSwap.v
@@ -15,7 +15,8 @@ Section Compile.
   Lemma compile_cswap_nocopy :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R R' functions T (pred: T -> _ -> Prop)
+      tr retvars R R' functions
+      T (pred: T -> list word -> _ -> Prop)
       {data} (x y : data) swap swap_var x_var x_ptr y_var y_ptr k k_impl
       (Data : word -> data -> Semantics.mem -> Prop) tmp,
       x_var <> y_var ->
@@ -30,6 +31,7 @@ Section Compile.
       (let head := v in
        (find k_impl
         implementing (pred (k head))
+        and-returning retvars
         and-locals-post locals_ok
         with-locals
                (map.put (map.put locals
@@ -51,6 +53,7 @@ Section Compile.
                   (cmd.skip))
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -86,7 +89,8 @@ Section Compile.
   Lemma compile_cswap_pair :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R functions T (pred: T -> _ -> Prop)
+           tr retvars R functions
+           T (pred: T -> list word -> _ -> Prop)
       {data} (x y : data * data) swap k k_impl,
       let v := cswap swap x y in
       (let __ := 0 in (* placeholder *)
@@ -98,6 +102,7 @@ Section Compile.
                                             let x := (fst xy1, fst xy2) in
                                             let y := (snd xy1, snd xy2) in
                                             k (x, y)))))
+        and-returning retvars
         and-locals-post locals_ok
         with-locals locals
         and-memory mem and-trace tr and-rest R
@@ -105,6 +110,7 @@ Section Compile.
       (let head := v in
        find k_impl
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).

--- a/src/Examples/ECC/DownTo.v
+++ b/src/Examples/ECC/DownTo.v
@@ -93,7 +93,8 @@ Section Compile.
          (Inv (map.remove l i_var) gst st * R')%sep m ->
          word.unsigned wi = Z.of_nat i ->
          i < count ->
-         exists l',
+         exists new_locals,
+           let l' := new_locals in
            find step_impl
            implementing (Inv (map.remove l' i_var) gst' (step st i))
            and-locals-post (fun l => l = l' /\ map.get l i_var = Some wi)

--- a/src/Examples/ECC/Field.v
+++ b/src/Examples/ECC/Field.v
@@ -118,18 +118,17 @@ Section Specs.
     forall! (x : bignum) (px pout : word) (old_out : bignum),
       (sep (Bignum px x * Bignum pout old_out)%sep)
         ===> bignum_copy @ [px; pout] ===>
-        (fun _ =>
-           Bignum px x * Bignum pout x)%sep.
+        (fun _ => Bignum px x * Bignum pout x)%sep.
 
   Instance spec_of_bignum_literal : spec_of bignum_literal :=
     forall! (x pout : word) (old_out : bignum),
       (sep (Bignum pout old_out))
         ===> bignum_literal @ [x; pout] ===>
         (fun _ =>
-           Lift1Prop.ex1
-           (fun X => (emp (eval X mod M = word.unsigned x mod M
-                           /\ bounded_by tight_bounds X)
-                      * Bignum pout X)%sep)).
+           liftexists X,
+           (emp (eval X mod M = word.unsigned x mod M
+                 /\ bounded_by tight_bounds X)
+            * Bignum pout X)%sep).
 End Specs.
 Existing Instances spec_of_mul spec_of_square spec_of_add
          spec_of_sub spec_of_scmula24 spec_of_inv spec_of_bignum_copy
@@ -460,7 +459,8 @@ Section Compile.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
     repeat straightline'.
-    eauto.
+    use_hyp_with_matching_cmd; eauto;
+      ecancel_assumption.
   Qed.
 
   Lemma compile_bignum_literal :

--- a/src/Examples/ECC/Field.v
+++ b/src/Examples/ECC/Field.v
@@ -68,7 +68,8 @@ Section Specs.
            /\ (exists Ra, (Bignum px x * Ra)%sep mem)
            /\ (Bignum pout old_out * Rr)%sep mem)
           ===> name @ [px; pout] ===>
-          (liftexists out,
+          (fun _ =>
+           liftexists out,
            (emp ((eval out mod M = (op (eval x)) mod M)%Z
                  /\ bounded_by outbounds out)
             * Bignum pout out)%sep))
@@ -82,7 +83,8 @@ Section Specs.
            /\ (exists Ra, (Bignum px x * Bignum py y * Ra)%sep mem)
            /\ (Bignum pout old_out * Rr)%sep mem)
           ===> name @ [px; py; pout] ===>
-          (liftexists out,
+          (fun _ =>
+           liftexists out,
            (emp ((eval out mod M = (op (eval x) (eval y)) mod M)%Z
                  /\ bounded_by outbounds out)
             * Bignum pout out)%sep)) (only parsing).
@@ -106,7 +108,8 @@ Section Specs.
            /\ (exists Ra, (Bignum px x * Ra)%sep mem)
            /\ (Bignum pout old_out * Rr)%sep mem)
           ===> inv @ [px; pout] ===>
-          (liftexists out,
+          (fun _ =>
+           liftexists out,
            (emp ((eval out mod M = (Finv (eval x mod M)) mod M)%Z
                  /\ bounded_by loose_bounds out)
             * Bignum pout out)%sep)).
@@ -115,13 +118,15 @@ Section Specs.
     forall! (x : bignum) (px pout : word) (old_out : bignum),
       (sep (Bignum px x * Bignum pout old_out)%sep)
         ===> bignum_copy @ [px; pout] ===>
-        (Bignum px x * Bignum pout x)%sep.
+        (fun _ =>
+           Bignum px x * Bignum pout x)%sep.
 
   Instance spec_of_bignum_literal : spec_of bignum_literal :=
     forall! (x pout : word) (old_out : bignum),
       (sep (Bignum pout old_out))
         ===> bignum_literal @ [x; pout] ===>
-        (Lift1Prop.ex1
+        (fun _ =>
+           Lift1Prop.ex1
            (fun X => (emp (eval X mod M = word.unsigned x mod M
                            /\ bounded_by tight_bounds X)
                       * Bignum pout X)%sep)).
@@ -148,7 +153,7 @@ Section Compile.
   Lemma compile_mul :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rin Rout functions T (pred: T -> _ -> Prop)
+      tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x y out : bignum) x_ptr x_var y_ptr y_var out_ptr out_var
       k k_impl,
       spec_of_mul functions ->
@@ -167,6 +172,7 @@ Section Compile.
          sep (Bignum out_ptr out) Rout m ->
          (find k_impl
           implementing (pred (k (eval out mod M)))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
@@ -176,6 +182,7 @@ Section Compile.
                                    expr.var out_var])
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -194,7 +201,7 @@ Section Compile.
   Lemma compile_add :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rin Rout functions T (pred: T -> _ -> Prop)
+      tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x y out : bignum) x_ptr x_var y_ptr y_var out_ptr out_var
       k k_impl,
       spec_of_add functions ->
@@ -213,6 +220,7 @@ Section Compile.
          sep (Bignum out_ptr out) Rout m ->
          (find k_impl
           implementing (pred (k (eval out mod M)))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
@@ -222,6 +230,7 @@ Section Compile.
                                    expr.var out_var])
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -240,7 +249,7 @@ Section Compile.
   Lemma compile_sub :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rin Rout functions T (pred: T -> _ -> Prop)
+      tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x y out : bignum) x_ptr x_var y_ptr y_var out_ptr out_var
       k k_impl,
       spec_of_sub functions ->
@@ -259,6 +268,7 @@ Section Compile.
          sep (Bignum out_ptr out) Rout m ->
          (find k_impl
           implementing (pred (k (eval out mod M)))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
@@ -268,6 +278,7 @@ Section Compile.
                                    expr.var out_var])
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -286,7 +297,7 @@ Section Compile.
   Lemma compile_square :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rin Rout functions T (pred: T -> _ -> Prop)
+      tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x out : bignum) x_ptr x_var out_ptr out_var k k_impl,
       spec_of_square functions ->
       bounded_by loose_bounds x ->
@@ -302,6 +313,7 @@ Section Compile.
          sep (Bignum out_ptr out) Rout m ->
          (find k_impl
           implementing (pred (k (eval out mod M)))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
@@ -310,6 +322,7 @@ Section Compile.
                (cmd.call [] square [expr.var x_var; expr.var out_var])
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -329,7 +342,7 @@ Section Compile.
   Lemma compile_scmula24 :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rin Rout functions T (pred: T -> _ -> Prop)
+      tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x out : bignum) x_ptr x_var out_ptr out_var k k_impl,
       spec_of_scmula24 functions ->
       bounded_by loose_bounds x ->
@@ -345,6 +358,7 @@ Section Compile.
          sep (Bignum out_ptr out) Rout m ->
          (find k_impl
           implementing (pred (k (eval out mod M)))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
@@ -353,6 +367,7 @@ Section Compile.
                (cmd.call [] scmula24 [expr.var x_var; expr.var out_var])
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -371,7 +386,7 @@ Section Compile.
   Lemma compile_inv :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rin Rout functions T (pred: T -> _ -> Prop)
+      tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x out : bignum) x_ptr x_var out_ptr out_var k k_impl,
       spec_of_inv functions ->
       bounded_by tight_bounds x ->
@@ -387,6 +402,7 @@ Section Compile.
          sep (Bignum out_ptr out) Rout m ->
          (find k_impl
           implementing (pred (k (eval out mod M)))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
@@ -395,6 +411,7 @@ Section Compile.
                (cmd.call [] inv [expr.var x_var; expr.var out_var])
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -413,7 +430,7 @@ Section Compile.
   Lemma compile_bignum_copy :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R R' functions T (pred: T -> _ -> Prop)
+      tr retvars R R' functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x out : bignum) x_ptr x_var out_ptr out_var k k_impl,
       spec_of_bignum_copy functions ->
       (Bignum x_ptr x * Placeholder out_ptr out * R')%sep mem ->
@@ -425,6 +442,7 @@ Section Compile.
          (Bignum x_ptr x * Bignum out_ptr x * R')%sep m ->
          (find k_impl
           implementing (pred (k head))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
@@ -433,6 +451,7 @@ Section Compile.
                (cmd.call [] bignum_copy [expr.var x_var; expr.var out_var])
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -447,7 +466,7 @@ Section Compile.
   Lemma compile_bignum_literal :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R R' functions T (pred: T -> _ -> Prop)
+      tr retvars R R' functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (wx : word) (x : Z) (out : bignum) out_ptr out_var k k_impl,
       spec_of_bignum_literal functions ->
       (Placeholder out_ptr out * R')%sep mem ->
@@ -461,6 +480,7 @@ Section Compile.
          bounded_by tight_bounds X ->
          (find k_impl
           implementing (pred (k head))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
@@ -470,6 +490,7 @@ Section Compile.
                          [expr.literal x; expr.var out_var])
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -491,7 +512,7 @@ Section Compile.
   Lemma compile_compose_l :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rout functions T (pred: T -> _ -> Prop)
+      tr retvars R Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (op1 op2 : Z -> Z -> Z)
       x y z out out_ptr out_var k k_impl,
       (Placeholder out_ptr out * Rout)%sep mem ->
@@ -501,12 +522,14 @@ Section Compile.
        (find k_impl
         implementing (pred (dlet (op1 x y mod M)
         (fun xy => dlet ((overwrite2 op2) xy z mod M) k)))
+        and-returning retvars
         and-locals-post locals_ok
         with-locals locals and-memory mem and-trace tr and-rest R
         and-functions functions)) ->
       (let head := v in
        find k_impl
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -518,7 +541,7 @@ Section Compile.
   Lemma compile_compose_r :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rout functions T (pred: T -> _ -> Prop)
+      tr retvars R Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (op1 op2 : Z -> Z -> Z)
       x y z out out_ptr out_var k k_impl,
       (Placeholder out_ptr out * Rout)%sep mem ->
@@ -528,12 +551,14 @@ Section Compile.
        (find k_impl
         implementing (pred (dlet (op1 x y mod M)
         (fun xy => dlet ((overwrite1 op2) z xy mod M) k)))
+        and-returning retvars
         and-locals-post locals_ok
         with-locals locals and-memory mem and-trace tr and-rest R
         and-functions functions)) ->
       (let head := v in
        find k_impl
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -545,7 +570,7 @@ Section Compile.
   Lemma compile_overwrite1 :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rin functions T (pred: T -> _ -> Prop)
+      tr retvars R Rin functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x : Z) (op : Z -> Z -> Z) (y : bignum) y_ptr y_var k k_impl,
       (Bignum y_ptr y * Rin)%sep mem ->
       map.get locals y_var = Some y_ptr ->
@@ -556,12 +581,14 @@ Section Compile.
          sep (Placeholder y_ptr y) Rin m ->
          (find k_impl
           implementing (pred (dlet v' k))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
       (let head := v in
        find k_impl
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -573,7 +600,7 @@ Section Compile.
   Lemma compile_overwrite2 :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R Rin functions T (pred: T -> _ -> Prop)
+      tr retvars R Rin functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (y : Z) (op : Z -> Z -> Z) (x : bignum) x_ptr x_var k k_impl,
       (Bignum x_ptr x * Rin)%sep mem ->
       map.get locals x_var = Some x_ptr ->
@@ -584,12 +611,14 @@ Section Compile.
          sep (Placeholder x_ptr x) Rin m ->
          (find k_impl
           implementing (pred (dlet v' k))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
           and-functions functions)) ->
       (let head := v in
        find k_impl
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).

--- a/src/Examples/ECC/LadderStep.v
+++ b/src/Examples/ECC/LadderStep.v
@@ -64,7 +64,7 @@ Section __.
                   A' AA' B' BB' E' C' D' DA' CB' (* new intermediates *)
        : bignum,
          (emp (result = ((eval X4 mod M, eval Z4 mod M),
-                         (eval X5 mod M, eval Z5 mod M))
+                            (eval X5 mod M, eval Z5 mod M))
                /\ bounded_by tight_bounds X4
                /\ bounded_by tight_bounds Z4
                /\ bounded_by tight_bounds X5
@@ -187,7 +187,7 @@ Section __.
       repeat straightline'.
       repeat match goal with H : eval _ mod _ = _ |- _ =>
                              rewrite H in * end.
-      auto.
+      eauto.
     Qed.
 
   Ltac ladderstep_compile_custom :=

--- a/src/Examples/ECC/LadderStep.v
+++ b/src/Examples/ECC/LadderStep.v
@@ -58,22 +58,23 @@ Section __.
              (pX1 pX2 pZ2 pX3 pZ3 : Semantics.word)
              (pA pAA pB pBB pE pC pD pDA pCB : Semantics.word)
              (result : point * point)
-    : Semantics.mem -> Prop :=
-    (liftexists X4 Z4 X5 Z5 (* output values *)
-                A' AA' B' BB' E' C' D' DA' CB' (* new intermediates *)
-     : bignum,
-       (emp (result = ((eval X4 mod M, eval Z4 mod M),
-                       (eval X5 mod M, eval Z5 mod M))
-             /\ bounded_by tight_bounds X4
-             /\ bounded_by tight_bounds Z4
-             /\ bounded_by tight_bounds X5
-             /\ bounded_by tight_bounds Z5)
-        * (Bignum pX1 X1 * Bignum pX2 X4 * Bignum pZ2 Z4
-           * Bignum pX3 X5 * Bignum pZ3 Z5
-           * Bignum pA A' * Bignum pAA AA'
-           * Bignum pB B' * Bignum pBB BB'
-           * Bignum pE E' * Bignum pC C' * Bignum pD D'
-           * Bignum pDA DA' * Bignum pCB CB'))%sep).
+    : list word -> Semantics.mem -> Prop :=
+    fun _ =>
+      (liftexists X4 Z4 X5 Z5 (* output values *)
+                  A' AA' B' BB' E' C' D' DA' CB' (* new intermediates *)
+       : bignum,
+         (emp (result = ((eval X4 mod M, eval Z4 mod M),
+                         (eval X5 mod M, eval Z5 mod M))
+               /\ bounded_by tight_bounds X4
+               /\ bounded_by tight_bounds Z4
+               /\ bounded_by tight_bounds X5
+               /\ bounded_by tight_bounds Z5)
+          * (Bignum pX1 X1 * Bignum pX2 X4 * Bignum pZ2 Z4
+             * Bignum pX3 X5 * Bignum pZ3 Z5
+             * Bignum pA A' * Bignum pAA AA'
+             * Bignum pB B' * Bignum pBB BB'
+             * Bignum pE E' * Bignum pC C' * Bignum pD D'
+             * Bignum pDA DA' * Bignum pCB CB'))%sep).
 
   Instance spec_of_ladderstep : spec_of "ladderstep" :=
     forall! (X1 X2 Z2 X3 Z3 A AA B BB E C D DA CB : bignum)
@@ -106,7 +107,7 @@ Section __.
     Lemma compile_ladderstep :
       forall (locals: Semantics.locals) (mem: Semantics.mem)
         (locals_ok : Semantics.locals -> Prop)
-        tr R R' functions T (pred: T -> _ -> Prop)
+        tr retvars R R' functions T (pred: T -> _ -> _ -> Prop)
         x1 x2 z2 x3 z3
         X1 X1_ptr X1_var X2 X2_ptr X2_var Z2 Z2_ptr Z2_var
         X3 X3_ptr X3_var Z3 Z3_ptr Z3_var
@@ -154,9 +155,10 @@ Section __.
            (LadderStepResult
              X1 X2 Z2 X3 Z3 X1_ptr X2_ptr Z2_ptr X3_ptr
              Z3_ptr A_ptr AA_ptr B_ptr BB_ptr E_ptr C_ptr D_ptr DA_ptr
-             CB_ptr head * R')%sep m ->
+             CB_ptr head [] * R')%sep m ->
            (find k_impl
             implementing (pred (k head))
+            and-returning retvars
             and-locals-post locals_ok
             with-locals locals
             and-memory m and-trace tr and-rest R
@@ -174,6 +176,7 @@ Section __.
 
                  k_impl)
          implementing (pred (dlet head k))
+         and-returning retvars
          and-locals-post locals_ok
          with-locals locals
          and-memory mem and-trace tr and-rest R

--- a/src/Examples/ECC/MontgomeryLadder.v
+++ b/src/Examples/ECC/MontgomeryLadder.v
@@ -392,8 +392,7 @@ Section __.
                                 subst gst' end.
         destruct_products.
         cbv [downto_inv] in * |-. sepsimpl_hyps.
-        evar (new_locals : map.rep (map:=Semantics.locals));
-              exists new_locals.
+        eexists; intros.
 
         (* convert locals back to literal map using the separation-logic
            condition; an alternative would be to have all lemmas play nice with
@@ -406,6 +405,7 @@ Section __.
         literal_locals_from_sep.
 
         repeat safe_compile_step.
+        cbv zeta.
 
         match goal with
         | |- context [dlet (ladderstep_gallina _ (?x1, ?z1) (?x2, ?z2))] =>
@@ -499,6 +499,7 @@ Section __.
         literal_locals_from_sep.
 
         repeat safe_compile_step.
+        cbv match zeta.
 
         (* pull the eval out of all the swaps so field lemmas work *)
         repeat match goal with

--- a/src/Examples/ECC/MontgomeryLadder.v
+++ b/src/Examples/ECC/MontgomeryLadder.v
@@ -78,7 +78,8 @@ Section __.
                (K : scalar)
                (pK pU pX1 pZ1 pX2 pZ2 pA pAA pB pBB pE pC pD pDA pCB : Semantics.word)
                (result : Z)
-      : Semantics.mem -> Prop :=
+      : list word -> Semantics.mem -> Prop :=
+      fun _ =>
       (liftexists U' X1' Z1' X2' Z2' A' AA' B' BB' E' C' D' DA' CB' : bignum,
          (emp (result = eval U' mod M)
           * (Scalar pK K * Bignum pU U'
@@ -154,6 +155,7 @@ Section __.
                K K_ptr X1_ptr Z1_ptr X2_ptr Z2_ptr Rl
                A_ptr AA_ptr B_ptr BB_ptr E_ptr C_ptr D_ptr DA_ptr CB_ptr
                (locals : Semantics.locals)
+               (_ : nat)
                (gst : bool)
                (st : point * point * bool)
       : Semantics.mem -> Prop :=

--- a/src/Examples/ECC/MontgomeryLadder.v
+++ b/src/Examples/ECC/MontgomeryLadder.v
@@ -279,31 +279,6 @@ Section __.
       [ first [ solve [repeat compile_step]
               | solve [straightline_map_solver_locals] ] .. | idtac ].
 
-    (* TODO: move? *)
-    Ltac remove_unused_var :=
-      let v :=
-          (lazymatch goal with
-           | |- find _ implementing ?pred ?k
-                and-locals-post ?P with-locals ?l
-                and-memory _ and-trace _ and-rest _ and-functions _ =>
-             lazymatch k with
-             | dlet _ _ => fail "compilation not complete!"
-             | _ =>
-               match l with
-               | context [map.put _ ?n] =>
-                 lazymatch P with
-                 | context [n] => fail
-                  | _ => lazymatch pred with
-                         | context [n] => fail
-                         | _ => n
-                         end
-                 end
-               end
-             end
-           end) in
-      eapply compile_unset with (var := v); [ ];
-      push_map_remove.
-
     Ltac solve_field_subgoals_with_cswap :=
       lazymatch goal with
       | |- map.get _ _ = Some _ =>

--- a/src/Examples/ECC/MontgomeryLadder.v
+++ b/src/Examples/ECC/MontgomeryLadder.v
@@ -158,6 +158,7 @@ Section __.
                (_ : nat)
                (gst : bool)
                (st : point * point * bool)
+               (_ : list word)
       : Semantics.mem -> Prop :=
       let P1 := fst (fst st) in
       let P2 := snd (fst st) in

--- a/src/Examples/ECC/Point.v
+++ b/src/Examples/ECC/Point.v
@@ -14,7 +14,7 @@ Section Compile.
   Lemma compile_point_assign :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R functions T (pred: T -> _ -> Prop)
+      tr retvars R functions T (pred: T -> _ -> _ -> Prop)
       (x y : Z) k k_impl,
       let v := (x mod M, y mod M)%Z in
       (let __ := 0 in (* placeholder *)
@@ -22,12 +22,14 @@ Section Compile.
        implementing (pred (dlet (x mod M)%Z
                                 (fun x => dlet (y mod M)%Z
                                                (fun y => k (x, y)))))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions) ->
       (let head := v in
        find k_impl
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).

--- a/src/Examples/ECC/ScalarField.v
+++ b/src/Examples/ECC/ScalarField.v
@@ -40,7 +40,8 @@ Section Specs.
           ===>
           sctestbit @ [px; wi] returns r
           ===>
-          (emp (r = word.of_Z (Z.b2z b)))).
+          (fun rets => emp (rets = [r]
+                            /\ r = word.of_Z (Z.b2z b)))).
 End Specs.
 Existing Instances spec_of_sctestbit.
 
@@ -53,7 +54,8 @@ Section Compile.
   Lemma compile_sctestbit :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R R' functions T (pred: T -> _ -> Prop)
+           tr retvars R R' functions
+           T (pred: T -> list word -> Semantics.mem -> Prop)
       x x_ptr x_var i wi i_var k k_impl var,
       spec_of_sctestbit functions ->
       (Scalar x_ptr x * R')%sep mem ->
@@ -66,6 +68,7 @@ Section Compile.
          (Scalar x_ptr x * R')%sep m ->
          (find k_impl
           implementing (pred (k head))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals (map.put locals var (word.of_Z (Z.b2z head)))
           and-memory m and-trace tr and-rest R
@@ -75,6 +78,7 @@ Section Compile.
                (cmd.call [var] sctestbit [expr.var x_var; expr.var i_var])
                k_impl)
        implementing (pred (dlet head k))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).

--- a/src/Examples/ECC/ScalarField.v
+++ b/src/Examples/ECC/ScalarField.v
@@ -38,10 +38,11 @@ Section Specs.
            (exists Ra, (Scalar px x * Ra)%sep mem)
            /\ Rr mem)
           ===>
-          sctestbit @ [px; wi] returns r
+          sctestbit @ [px; wi] returns rets
           ===>
-          (fun rets => emp (rets = [r]
-                            /\ r = word.of_Z (Z.b2z b)))).
+          (liftexists r,
+           emp (rets = [r]
+                /\ r = word.of_Z (Z.b2z b)))).
 End Specs.
 Existing Instances spec_of_sctestbit.
 

--- a/src/Examples/KVStore/Automated.v
+++ b/src/Examples/KVStore/Automated.v
@@ -196,10 +196,11 @@ Section KVSwap.
    *)
 
   Definition MapAndTwoKeys pm pk1 pk2 v :=
-    let m := fst (fst v) in
-    let k1 := snd (fst v) in
-    let k2 := snd v in
-    (Map pm m * Key pk1 k1 * Key pk2 k2)%sep.
+    fun _ : list word =>
+      let m := fst (fst v) in
+      let k1 := snd (fst v) in
+      let k2 := snd v in
+      (Map pm m * Key pk1 k1 * Key pk2 k2)%sep.
 
   Definition deannotate (m : annotated_map) : map.rep (map:=map) :=
     map.fold
@@ -246,7 +247,7 @@ Section KVSwap.
   Lemma compile_map_get :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-           tr R R' functions T (pred: T -> _ -> Prop)
+           tr retvars R R' functions T (pred: T -> _ -> _ -> Prop)
            m m_ptr m_var M
            k k_ptr k_var
            default default_impl
@@ -265,6 +266,7 @@ Section KVSwap.
           (AnnotatedMap m_ptr M * Key k_ptr k * R')%sep mem' ->
           find default_impl
           implementing (pred default)
+          and-returning retvars
           and-locals-post locals_ok
           with-locals (map.put (map.put locals err (word.of_Z 1))
                             var garbage)
@@ -278,6 +280,7 @@ Section KVSwap.
            * Key k_ptr k * R')%sep mem' ->
           find K_impl
           implementing (pred (K head))
+          and-returning retvars
           and-locals-post locals_ok
           with-locals (map.put (map.put locals err (word.of_Z 0))
                             var hd_ptr)
@@ -290,6 +293,7 @@ Section KVSwap.
                          K_impl
                          default_impl))
        implementing (pred (do_or_default head K default))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).
@@ -402,7 +406,7 @@ Section KVSwap.
   Lemma compile_map_put_replace :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-           tr R R' functions T (pred: T -> _ -> Prop)
+           tr retvars R R' functions T (pred: T -> _ -> _ -> Prop)
            m m_ptr m_var M
            k k_ptr k_var
            v v_ptr v_var
@@ -421,6 +425,7 @@ Section KVSwap.
           * Key k_ptr k * R')%sep mem' ->
          find K_impl
          implementing (pred (K head))
+         and-returning retvars
          and-locals-post locals_ok
          with-locals locals
          and-memory mem' and-trace tr and-rest R
@@ -432,6 +437,7 @@ Section KVSwap.
                          [expr.var m_var; expr.var k_var; expr.var v_var])
                K_impl)
        implementing (pred (dlet head K))
+       and-returning retvars
        and-locals-post locals_ok
        with-locals locals and-memory mem and-trace tr and-rest R
        and-functions functions).

--- a/src/Examples/LinkedList/Find.v
+++ b/src/Examples/LinkedList/Find.v
@@ -1,0 +1,233 @@
+Require Import Rupicola.Lib.Api.
+Require Import Rupicola.Lib.SepLocals.
+Require Import Rupicola.Examples.ECC.DownTo.
+Require Import Rupicola.Examples.LinkedList.LinkedList.
+
+Section Gallina.
+  (* returns the portion of the linked list headed by the first element x for
+     which [f x = true]; if there is no such element, returns an empty list *)
+  (* N.B. n should be the length of the list *)
+  Definition ll_find
+             {A} (d : A) (f : A -> bool) (ls : linkedlist A) (n : nat)
+  : linkedlist A :=
+    let/d p := ls in
+    let/d x := downto p n
+                      (fun st _ =>
+                         let/d x := ll_hd d st in
+                         let/d c := f x in
+                         let/d p := ll_next st in
+                         let/d st' := if c then st else p in
+                         st') in
+  x.
+End Gallina.
+
+Section Compile.
+  Context {semantics : Semantics.parameters}
+          {semantics_ok : Semantics.parameters_ok semantics}.
+  (* TODO: generalize *)
+  Local Notation LinkedList :=
+    (@LinkedList semantics word access_size.word scalar) (only parsing).
+  Local Notation word_size_in_bytes :=
+    (@Memory.bytes_per Semantics.width access_size.word).
+  Local Notation next_word :=
+    (fun p : address =>
+       word.add p (word.of_Z (Z.of_nat word_size_in_bytes))).
+
+  Definition LLFindResult
+             (end_ptr pll : address)
+             (ll : linkedlist word) (x : word)
+             (result : linkedlist word)
+             (rets : list word)
+    : Semantics.mem -> Prop :=
+    liftexists px ll1,
+    (emp (rets = [px]
+          /\ ll = (ll1 ++ result)%list)
+     * LinkedList px pll ll1
+     * LinkedList end_ptr px result)%sep.
+
+  Instance spec_of_ll_find : spec_of "ll_find" :=
+    (forall! (end_ptr pll : address) (ll : linkedlist word)
+           (n x dummy : word),
+        (sep (emp (word.unsigned n = Z.of_nat (length ll)
+                   /\ 0 < length ll)
+              * LinkedList end_ptr pll ll)%sep)
+          ===>
+          "ll_find" @ [pll; n; x] returns rets
+          ===>
+          LLFindResult
+            end_ptr pll ll x
+            (ll_find dummy (word.eqb x) ll (length ll)) rets).
+
+  Definition downto_inv
+             (ll : linkedlist word)
+             (x end_ptr pll : address)
+             (x_var p_var : string)
+             (locals : Semantics.locals)
+             (i : nat)
+             (gst : linkedlist word)
+             (st : linkedlist word)
+             (_ : list word) (* TODO: use this? *)
+    : Semantics.mem -> Prop :=
+    let ll1 := gst in
+    liftexists p,
+    (emp (i <= length st
+          /\ ll = (gst ++ st)%list
+          /\ map.get locals x_var = Some x
+          /\ map.get locals p_var = Some p)
+     * LinkedList p pll ll1 * LinkedList end_ptr p st)%sep.
+
+  Derive ll_find_body SuchThat
+         (let args := ["pll"; "n"; "x"] in
+          let rets := ["p"] in
+          let ll_find := ("ll_find", (args, rets, ll_find_body)) in
+          program_logic_goal_for
+            ll_find
+            (ltac:(let x := program_logic_goal_for_function
+                              ll_find (@nil string) in
+                   exact x)))
+         As ll_find_body_correct.
+  Proof.
+    cbv [spec_of_ll_find].
+    setup. sepsimpl.
+    pose (p_var := "p").
+    pose (n_var := "n").
+    pose (x_var := "x").
+    simple eapply compile_pointer with (var:=p_var);
+      [ solve [compile_step] .. | ].
+    compile_step.
+
+    let x_var := (eval hnf in x_var) in
+    let x := match goal with |- context [map.put _ x_var ?x] => x end in
+    simple eapply compile_downto
+      with
+        (ginit := [])
+        (i_var := n_var)
+        (ghost_step :=
+           fun st gst _ =>
+             if (word.eqb x (ll_hd dummy st))
+             then gst else (gst ++ [ll_hd dummy st])%list)
+        (Inv := downto_inv ll x end_ptr pll x_var p_var).
+    all:lazymatch goal with
+        | |- word.unsigned _ = Z.of_nat _ => solve [eauto]
+        | |- context [WeakestPrecondition.cmd] => idtac
+        | |- sep _ _ _ =>
+          cbv [downto_inv];
+            cbn [fst snd List.app LinkedList];
+            lift_eexists; sepsimpl
+        | _ => idtac
+        end.
+    all:lazymatch goal with
+        | |- sep _ _ _ => ecancel_assumption
+        | _ => idtac
+        end.
+    all:lazymatch goal with
+        | |- context [WeakestPrecondition.cmd] => idtac
+        | |- _ <> [] =>
+          subst_lets_in_goal; rewrite <-length_zero_iff_nil; lia
+        | |- ?x = ?x => reflexivity
+        | |- map.get _ _ = Some _ =>
+          subst_lets_in_goal; try push_map_remove;
+            autorewrite with mapsimpl; try reflexivity
+        | _ => solve [eauto]
+        end.
+
+    { (* compile loop body *)
+      intros. clear_old_seps.
+      cbv [downto_inv] in *|-.
+      sepsimpl_hyps. cleanup; subst.
+
+      repeat match goal with H : map.get (map.remove _ _) _ = _ |- _ =>
+                             rewrite map.get_remove_diff in H
+                               by (subst_lets_in_goal; congruence)
+             end.
+      match goal with
+      | H : _ <= length ?st,
+            Hll : context [LinkedList.LinkedList _ _ ?st] |- _ =>
+        rewrite (ll_hd_next_eq st dummy) in *
+          by (destruct st; cbn [length] in H; congruence || lia)
+      end.
+      cbn [LinkedList] in *|-.
+      sepsimpl_hyps.
+      cbn beta iota delta [ll_hd hd ll_next tl].
+
+      eexists; intros.
+
+      gen_sym_inc.
+      let v := gen_sym_fetch "v" in
+      simple eapply compile_ll_hd with (var:=v).
+      all:lazymatch goal with
+          | |- sep _ _ _ =>
+            cbn [ll_hd hd ll_next tl]; ecancel_assumption
+          | _ => idtac
+          end.
+      all:lazymatch goal with
+          | |- context [WeakestPrecondition.cmd] => idtac
+          | _ => solve [compile_step]
+          end.
+
+      intros. clear_old_seps.
+
+      repeat safe_compile_step.
+
+      gen_sym_inc.
+      let v := gen_sym_fetch "v" in
+      simple eapply compile_ll_next with (var:=v);
+        [ repeat compile_step .. | ];
+        [ try solve [repeat compile_step] .. | ].
+      repeat safe_compile_step.
+
+      simple eapply compile_if_pointer with (var:="p");
+        try ecancel_assumption.
+      { cbn [LinkedList].
+        cbn [ll_hd hd ll_next tl] in *.
+        sepsimpl. lift_eexists.
+        ecancel_assumption. }
+      all:lazymatch goal with
+          | |- context [WeakestPrecondition.cmd] => idtac
+          | _ => solve [compile_step]
+          end.
+
+      repeat safe_compile_step.
+
+      (* unset loop-local variables *)
+      repeat remove_unused_var.
+
+      compile_done.
+      { subst_lets_in_goal.
+        autorewrite with mapsimpl.
+        ssplit; reflexivity. }
+      { cbv [downto_inv].
+        lift_eexists; sepsimpl; subst_lets_in_goal.
+        { destruct_one_match; cbn [length] in *; lia. }
+        { destruct_one_match;
+            try rewrite <-app_assoc; reflexivity. }
+        { rewrite map.get_remove_diff by congruence.
+          autorewrite with mapsimpl. eauto. }
+        { rewrite map.get_remove_diff by congruence.
+          autorewrite with mapsimpl. eauto. }
+        { destruct_one_match.
+          all:cbn [LinkedList]; sepsimpl.
+          { lift_eexists; ecancel_assumption. }
+          { seprewrite @LinkedList_snoc_iff1.
+            sepsimpl. lift_eexists; sepsimpl.
+            ecancel_assumption. } } } }
+    { intros.
+      cbv [downto_inv] in *. sepsimpl_hyps.
+      repeat match goal with H : map.get (map.remove _ _) _ = _ |- _ =>
+                             rewrite map.get_remove_diff in H
+                               by (subst_lets_in_goal; congruence)
+             end.
+
+      (* TODO: make compile_done try to solve the map.getmany_of_list goal *)
+      compile_done;
+        [ subst p_var; eapply map.getmany_of_list_cons;
+          eauto; reflexivity | ].
+      cbv [LLFindResult].
+      lift_eexists; sepsimpl;
+        lazymatch goal with
+        | |- sep _ _ _ => ecancel_assumption
+        | _ => idtac
+        end.
+      all:eauto. }
+  Qed.
+End Compile.

--- a/src/Examples/LinkedList/LinkedList.v
+++ b/src/Examples/LinkedList/LinkedList.v
@@ -6,37 +6,43 @@ Section Gallina.
   Definition ll_hd {A} : A -> linkedlist A -> A := hd.
 
   Definition ll_next {A} : linkedlist A -> linkedlist A := tl.
-
-  Definition ll_empty {A} : linkedlist A -> bool :=
-    fun l => (length l =? 0)%nat.
 End Gallina.
 
 Section Separation.
   Context {semantics : Semantics.parameters}
           {semantics_ok : Semantics.parameters_ok semantics}.
-  Context {NULL : address -> Semantics.mem -> Prop}.
-  Context {element : Type}
+  Context {element : Type} {element_size : access_size}
           {Element : address -> element -> Semantics.mem -> Prop}.
 
-  Local Notation word_size_in_bytes :=
-    (@Memory.bytes_per Semantics.width access_size.word).
-  Local Notation next_word :=
+  Local Notation element_size_in_bytes :=
+    (@Memory.bytes_per Semantics.width element_size).
+  Local Notation skip_element :=
     (fun p : address =>
-       word.add p (word.of_Z (Z.of_nat word_size_in_bytes))).
+       word.add p (word.of_Z (Z.of_nat element_size_in_bytes))).
 
-  Fixpoint LinkedList (pl : address) (l : list element)
+  (* To have a LinkedList with elements inline, instantiate Element with
+     something like [scalar] or [ptsto], and set the element_size to word or one
+     respectively.
+
+     To have a LinkedList that holds pointers to its elements, set the
+     element_size to word and give Element an indirection. For example, to do a
+     LinkedList of scalars but with pointer-indirection, do:
+
+     element := word
+     Element := (fun (p : address) (x : word) =>
+                  Lift1Prop.ex1
+                    (fun px : address =>
+                      (scalar p px * scalar px x)%sep)) *)
+  Fixpoint LinkedList (end_ptr pl : address) (l : list element)
     : Semantics.mem -> Prop :=
     match l with
-    | [] => NULL pl
+    | [] => emp (pl = end_ptr)
     | e :: l' =>
       Lift1Prop.ex1
-        (fun pe =>
-           Lift1Prop.ex1
-             (fun pl' =>
-                (scalar pl pe
-                 * scalar (next_word pl) pl'
-                 * LinkedList pl' l'
-                 * Element pe e)%sep))
+        (fun pl' =>
+           (Element pl e
+            * scalar (skip_element pl) pl'
+            * LinkedList end_ptr pl' l')%sep)
     end.
 End Separation.
 
@@ -44,7 +50,6 @@ Section Compile.
   Context {semantics : Semantics.parameters}
           {semantics_ok : Semantics.parameters_ok semantics}.
   (* TODO: generalize
-  Context {NULL : address -> Semantics.mem -> Prop}.
   Context {element : Type}
           {Element : address -> element -> Semantics.mem -> Prop}.
   Context {element_eqb : element -> element -> bool}
@@ -52,13 +57,10 @@ Section Compile.
              forall x y : element,
                BoolSpec (x = y) (x <> y) (element_eqb x y)}.
   Local Notation LinkedList :=
-    (@LinkedList semantics NULL element Element).
+    (@LinkedList semantics element Element).
    *)
-  Local Notation NULL :=
-    (fun p : address => emp (map:=Semantics.mem)
-                            (word.eqb p (word.of_Z 0) = true)).
   Local Notation LinkedList :=
-    (@LinkedList semantics NULL word scalar) (only parsing).
+    (@LinkedList semantics word access_size.word scalar) (only parsing).
   Local Notation word_size_in_bytes :=
     (@Memory.bytes_per Semantics.width access_size.word).
   Local Notation next_word :=
@@ -71,24 +73,23 @@ Section Compile.
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
       tr R' R functions T (pred: T -> _ -> Prop)
-      d ll ll_var ll_ptr k k_impl var,
+      d end_ptr ll ll_var ll_ptr k k_impl var,
       map.get locals ll_var = Some ll_ptr ->
-      (LinkedList ll_ptr ll * R')%sep mem ->
+      (LinkedList end_ptr ll_ptr ll * R')%sep mem ->
       ll <> nil ->
       let v := ll_hd d ll in
       (let head := v in
-       forall m ll' px pll',
-         ll = head :: ll' ->
-         (scalar ll_ptr px
-          * scalar px head
+       forall m pll',
+         let ll' := ll_next ll in
+         (scalar ll_ptr head
           * scalar (next_word ll_ptr) pll'
-          * LinkedList pll' ll'
+          * LinkedList end_ptr pll' ll'
           * R')%sep m ->
          find k_impl
          implementing (pred (k head))
          and-locals-post locals_ok
-         with-locals (map.put locals var px)
-         and-memory mem and-trace tr and-rest R
+         with-locals (map.put locals var head)
+         and-memory m and-trace tr and-rest R
          and-functions functions) ->
       (let head := v in
        find (cmd.seq
@@ -112,24 +113,32 @@ Section Compile.
   Lemma compile_ll_next :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr R functions T (pred: T -> _ -> Prop)
-      (ll : linkedlist word) ll_var ll_ptr k k_impl var,
+      tr R' R functions T (pred: T -> _ -> Prop)
+      end_ptr (ll ll' : linkedlist word) ll_var ll_ptr ll'_ptr
+      dummy k k_impl var,
       map.get locals ll_var = Some ll_ptr ->
+      ll <> nil ->
+      (scalar ll_ptr (ll_hd dummy ll)
+       * scalar (next_word ll_ptr) ll'_ptr
+       * LinkedList end_ptr ll'_ptr (ll_next ll)
+       * R')%sep mem ->
       let v := ll_next ll in
       (let head := v in
        find k_impl
        implementing (pred (k head))
        and-locals-post locals_ok
-       with-locals (map.put locals var (next_word ll_ptr))
+       with-locals (map.put locals var ll'_ptr)
        and-memory mem and-trace tr and-rest R
        and-functions functions) ->
       (let head := v in
        find (cmd.seq
                (cmd.set var
-                        (expr.op bopname.add
-                                 (expr.var ll_var)
-                                 (expr.literal
-                                    (Z.of_nat word_size_in_bytes))))
+                        (expr.load
+                           access_size.word
+                           (expr.op bopname.add
+                                    (expr.var ll_var)
+                                    (expr.literal
+                                       (Z.of_nat word_size_in_bytes)))))
                k_impl)
        implementing (pred (dlet head k))
        and-locals-post locals_ok

--- a/src/Lib/Compiler.v
+++ b/src/Lib/Compiler.v
@@ -478,8 +478,7 @@ Section with_semantics.
 
   Lemma postcondition_func_postcondition_cmd
         (spec : list word -> Semantics.mem -> Prop)
-        k R tr mem locals retvars n functions :
-    length retvars = n ->
+        k R tr mem locals retvars functions :
     (WeakestPrecondition.cmd
        (WeakestPrecondition.call functions)
        k tr mem locals
@@ -492,16 +491,12 @@ Section with_semantics.
          WeakestPrecondition.list_map
            (WeakestPrecondition.get l) retvars
            (fun rets : list word =>
-              postcondition_func
-                (fun rets =>
-                   (emp (length rets = n) * (spec rets))%sep)
-                R tr tr' m' rets)).
+              postcondition_func spec R tr tr' m' rets)).
   Proof.
     cbv [postcondition_func postcondition_cmd]; intros.
     cleanup.
     use_hyp_with_matching_cmd; cleanup; subst.
     eapply getmany_list_map; sepsimpl; eauto.
-    eauto using map.getmany_of_list_length, eq_sym.
   Qed.
 End with_semantics.
 
@@ -522,10 +517,9 @@ Ltac setup :=
    end; cbv beta match delta [WeakestPrecondition.func]);
   repeat straightline; subst_lets_in_goal; cbn [length];
   first [ apply postcondition_func_norets_postcondition_cmd
-        | apply postcondition_func_postcondition_cmd;
-          [ cbn [length]; reflexivity | ] ];
+        | apply postcondition_func_postcondition_cmd ];
    match goal with
-   | |- context [ postcondition_cmd _ (fun r => _ ?spec r) ] =>
+   | |- context [ postcondition_cmd _ (?pred ?spec) ] =>
          let hd := term_head spec in
          unfold hd
    end.

--- a/src/Lib/Compiler.v
+++ b/src/Lib/Compiler.v
@@ -522,6 +522,9 @@ Ltac setup :=
    | |- context [ postcondition_cmd _ (?pred ?spec) ] =>
          let hd := term_head spec in
          unfold hd
+   | |- context [ postcondition_cmd _ (fun r => ?pred ?spec r) ] =>
+         let hd := term_head spec in
+         unfold hd
    end.
 
 Ltac lookup_variable m val :=

--- a/src/Lib/Core.v
+++ b/src/Lib/Core.v
@@ -118,6 +118,17 @@ Module map.
         rewrite ?map.get_put_diff, ?map.get_put_same by congruence;
         congruence.
     Qed.
+
+    Lemma getmany_of_list_cons m k ks v vs :
+      map.get m k = Some v ->
+      map.getmany_of_list m ks = Some vs ->
+      map.getmany_of_list m (k :: ks) = Some (v :: vs).
+    Proof.
+      intros. cbv [map.getmany_of_list] in *.
+      cbn [List.map List.option_all].
+      destruct_one_match; try congruence; [ ].
+      destruct_one_match; congruence.
+    Qed.
   End __.
 End map.
 

--- a/src/Lib/Notations.v
+++ b/src/Lib/Notations.v
@@ -91,7 +91,7 @@ Notation "'forall!' x .. y ',' pre '===>' fname '@' args 'returns' rets '===>' p
                   functions fname tr mem args
                   (postcondition_func (fun rets => post) R tr)) ..))
      (x binder, y binder, only parsing, at level 199).
-(* quick test for spec notation *)
+(* test for spec notation *)
 Check
   (fun (semantics : Semantics.parameters) =>
      (forall! (pa : address) (a b : word),
@@ -99,7 +99,16 @@ Check
            ===>
            "example" @ [pa; b] returns r
            ===>
-           (liftexists x, emp (r = [x]))%sep)).
+           (liftexists x, emp (r = [x]) * (pa ~> x))%sep)).
+(* test for spec notation *)
+Check
+  (fun (semantics : Semantics.parameters) =>
+     (forall! (pa : address) (a b : word),
+         (sep (pa ~> a))
+           ===>
+           "example" @ [pa; b] returns r
+           ===>
+           (emp (r = []) * (pa ~> word.add a b))%sep)).
 
 (* shorthand for no return values *)
 Notation "'forall!' x .. y ',' pre '===>' fname '@' args '===>' post" :=
@@ -112,7 +121,7 @@ Notation "'forall!' x .. y ',' pre '===>' fname '@' args '===>' post" :=
                   functions fname tr mem args
                   (postcondition_func_norets post R tr)) ..))
      (x binder, y binder, only parsing, at level 199).
-(* quick test for spec notation *)
+(* test for spec notation *)
 Check
   (fun (semantics : Semantics.parameters) =>
      (forall! (pa : address) (a b : word),

--- a/src/Lib/Notations.v
+++ b/src/Lib/Notations.v
@@ -44,8 +44,10 @@ Infix "~>" := scalar (at level 40, only parsing).
 Notation "[[ locals ]]" := ({| value := locals; _value_ok := _ |}) (only printing).
 
 Definition postcondition_func
-           {semantics : Semantics.parameters} spec R tr :=
-  (fun (tr' : Semantics.trace) (mem' : Semantics.mem) (rets : list address) =>
+           {semantics : Semantics.parameters}
+           (spec : list word -> Semantics.mem -> Prop)
+           R tr :=
+  (fun (tr' : Semantics.trace) (mem' : Semantics.mem) (rets : list word) =>
      tr = tr'
      /\ sep (spec rets) R mem').
 

--- a/src/Lib/Notations.v
+++ b/src/Lib/Notations.v
@@ -81,6 +81,27 @@ Notation "'liftexists' x .. y ',' P" :=
 
 (* precondition is more permissively handled than postcondition in order to
    non-separation-logic (or multiple separation-logic) preconditions *)
+Notation "'forall!' x .. y ',' pre '===>' fname '@' args 'returns' rets '===>' post" :=
+(fun functions =>
+   (forall x,
+       .. (forall y,
+              forall R tr mem,
+                pre R mem ->
+                WeakestPrecondition.call
+                  functions fname tr mem args
+                  (postcondition_func (fun rets => post) R tr)) ..))
+     (x binder, y binder, only parsing, at level 199).
+(* quick test for spec notation *)
+Check
+  (fun (semantics : Semantics.parameters) =>
+     (forall! (pa : address) (a b : word),
+         (sep (pa ~> a))
+           ===>
+           "example" @ [pa; b] returns r
+           ===>
+           (liftexists x, emp (r = [x]))%sep)).
+
+(* shorthand for no return values *)
 Notation "'forall!' x .. y ',' pre '===>' fname '@' args '===>' post" :=
 (fun functions =>
    (forall x,
@@ -89,7 +110,7 @@ Notation "'forall!' x .. y ',' pre '===>' fname '@' args '===>' post" :=
                 pre R mem ->
                 WeakestPrecondition.call
                   functions fname tr mem args
-                  (postcondition_func post R tr)) ..))
+                  (postcondition_func_norets post R tr)) ..))
      (x binder, y binder, only parsing, at level 199).
 (* quick test for spec notation *)
 Check
@@ -100,4 +121,3 @@ Check
            "example" @ [pa; b]
            ===>
            (fun _ => emp True)%sep)).
-

--- a/src/Lib/Notations.v
+++ b/src/Lib/Notations.v
@@ -91,24 +91,23 @@ Notation "'forall!' x .. y ',' pre '===>' fname '@' args 'returns' rets '===>' p
                   functions fname tr mem args
                   (postcondition_func (fun rets => post) R tr)) ..))
      (x binder, y binder, only parsing, at level 199).
-(* test for spec notation *)
-Check
-  (fun (semantics : Semantics.parameters) =>
+
+Example spec_example_withrets {semantics : Semantics.parameters}
+  : spec_of "example" :=
+  (forall! (pa : address) (a b : word),
+      (sep (pa ~> a))
+        ===>
+        "example" @ [pa; b] returns r
+        ===>
+        (liftexists x, emp (r = [x]) * (pa ~> x))%sep).
+Example spec_example_norets {semantics : Semantics.parameters}
+  : spec_of "example" :=
      (forall! (pa : address) (a b : word),
          (sep (pa ~> a))
            ===>
            "example" @ [pa; b] returns r
            ===>
-           (liftexists x, emp (r = [x]) * (pa ~> x))%sep)).
-(* test for spec notation *)
-Check
-  (fun (semantics : Semantics.parameters) =>
-     (forall! (pa : address) (a b : word),
-         (sep (pa ~> a))
-           ===>
-           "example" @ [pa; b] returns r
-           ===>
-           (emp (r = []) * (pa ~> word.add a b))%sep)).
+           (emp (r = []) * (pa ~> word.add a b))%sep).
 
 (* shorthand for no return values *)
 Notation "'forall!' x .. y ',' pre '===>' fname '@' args '===>' post" :=
@@ -121,12 +120,20 @@ Notation "'forall!' x .. y ',' pre '===>' fname '@' args '===>' post" :=
                   functions fname tr mem args
                   (postcondition_func_norets post R tr)) ..))
      (x binder, y binder, only parsing, at level 199).
-(* test for spec notation *)
-Check
-  (fun (semantics : Semantics.parameters) =>
-     (forall! (pa : address) (a b : word),
-         (sep (pa ~> a))
-           ===>
-           "example" @ [pa; b]
-           ===>
-           (fun _ => emp True)%sep)).
+
+(* N.B. postconditions with no return values still need to take in an argument
+   for return values to make types line up. However, the shorthand notation inserts
+   a clause to the postcondition saying the return values are nil, so the
+   postcondition does not need to ensure this. *)
+Example spec_example_norets_short {semantics : Semantics.parameters}
+  : spec_of "example" :=
+  (forall! (pa : address) (a b : word),
+      (sep (pa ~> a))
+        ===>
+        "example" @ [pa; b]
+        ===>
+        (fun _ => pa ~> word.add a b)%sep).
+
+(* unify short and long notations for functions without return values (fails if
+   spec_example_norets and spec_example_norets_short are not equivalent) *)
+Compute (let x := ltac:(unify @spec_example_norets @spec_example_norets_short) in x).

--- a/src/Lib/Notations.v
+++ b/src/Lib/Notations.v
@@ -81,48 +81,6 @@ Notation "'liftexists' x .. y ',' P" :=
 
 (* precondition is more permissively handled than postcondition in order to
    non-separation-logic (or multiple separation-logic) preconditions *)
-Notation "'forall!' x .. y ',' pre '===>' fname '@' args 'returns' a .. b '===>' post" :=
-  (fun functions =>
-     (forall x,
-         .. (forall y,
-                forall R tr mem,
-                  pre R mem ->
-                  WeakestPrecondition.call
-                    functions fname tr mem args
-                    (postcondition_func
-                       (fun rets =>
-                          let r := rets in
-                          (dlet (hd (word.of_Z 0) r)
-                                (fun a =>
-                                   let r := tl r in
-                                   ..
-                                     (dlet (hd (word.of_Z 0) r)
-                                           (fun b =>
-                                              let r := tl r in
-                                              sep
-                                                (emp (length rets = length (cons a .. (cons b nil) .. )))
-                                                (post rets))) ..)))
-                       R tr))
-            .. ))
-     (x binder, y binder, a binder, b binder, only parsing, at level 199).
-
-(* quick test for spec notation *)
-Check
-  (fun (semantics : Semantics.parameters) =>
-     let Result :=
-         (fun (pa : address) (b c d : word) (rets : list word) =>
-            sep (map:=Semantics.mem)
-                (emp (rets = [c;d]
-                      /\ c = word.add d b))
-                (pa ~> d)) in
-     (forall! (pa : address) (a b : word),
-         (sep (pa ~> a))
-           ===>
-           "example" @ [pa; b] returns c d e
-           ===>
-           Result pa b c d)).
-
-(* shorthand for no return values *)
 Notation "'forall!' x .. y ',' pre '===>' fname '@' args '===>' post" :=
 (fun functions =>
    (forall x,
@@ -131,7 +89,7 @@ Notation "'forall!' x .. y ',' pre '===>' fname '@' args '===>' post" :=
                 pre R mem ->
                 WeakestPrecondition.call
                   functions fname tr mem args
-                  (postcondition_func_norets post R tr)) ..))
+                  (postcondition_func post R tr)) ..))
      (x binder, y binder, only parsing, at level 199).
 (* quick test for spec notation *)
 Check
@@ -141,5 +99,5 @@ Check
            ===>
            "example" @ [pa; b]
            ===>
-           (emp True)%sep)).
+           (fun _ => emp True)%sep)).
 

--- a/src/Lib/SepLocals.v
+++ b/src/Lib/SepLocals.v
@@ -161,7 +161,7 @@ Ltac cancel_Var :=
 
 Ltac sep_from_literal_locals locals :=
   let R := locals_sep locals in
-  assert (R locals) by (repeat cancel_Var).
+  assert (R locals) by (try subst locals; repeat cancel_Var).
 
 Ltac literal_locals_from_sep :=
   let l := lazymatch goal with

--- a/src/Lib/SepLocals.v
+++ b/src/Lib/SepLocals.v
@@ -189,6 +189,7 @@ Ltac remove_unused_var :=
   let v :=
       (lazymatch goal with
        | |- find _ implementing ?pred ?k
+            and-returning ?retvars
             and-locals-post ?P with-locals ?l
             and-memory _ and-trace _ and-rest _ and-functions _ =>
          lazymatch k with
@@ -200,7 +201,11 @@ Ltac remove_unused_var :=
              | context [n] => fail
              | _ => lazymatch pred with
                     | context [n] => fail
-                    | _ => n
+                    | _ =>
+                      lazymatch retvars with
+                      | context [n] => fail
+                      | _ => n
+                      end
                     end
              end
            end

--- a/src/Lib/Tactics.v
+++ b/src/Lib/Tactics.v
@@ -73,7 +73,7 @@ Ltac clear_old_seps :=
          end.
 
 Ltac cleanup :=
-  repeat first [ progress cbn [fst snd eq_rect] in *
+  repeat first [ progress cbn beta iota delta [fst snd eq_rect] in *
                | match goal with H : _ /\ _ |- _ => destruct H end
                | match goal with H : exists _, _ |- _ => destruct H end
                | match goal with H : ?x = ?x |- _ => clear H end ].


### PR DESCRIPTION
Adds a new example for linked-liat find and includes updates to postconditions logic so that return variables are possible. Some of the latter is likely to change soon, but it seems worth merging the current state at this point.