### PR TITLE
bump bedrock2

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         env:
-        - { COQ_VERSION: "8.11.1", COQ_PACKAGE: "coq-8.11.1 libcoq-8.11.1-ocaml-dev", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
+        - { COQ_VERSION: "8.13.0", COQ_PACKAGE: "coq-8.13.0 libcoq-8.13.0-ocaml-dev", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
         - { COQ_VERSION: "master", COQ_PACKAGE: "coq libcoq-ocaml-dev"              , PPA: "ppa:jgross-h/coq-master-daily" }
 
     env: ${{ matrix.env }}

--- a/src/Rupicola/Examples/CapitalizeThird/Properties.v
+++ b/src/Rupicola/Examples/CapitalizeThird/Properties.v
@@ -95,13 +95,6 @@ Section Generalizable.
     apply IHxs; auto.
   Qed.
 
-  Lemma word_to_nat_to_word w :
-    w = word.of_Z (Z.of_nat (Z.to_nat (word.unsigned w))).
-  Proof.
-    rewrite Z2Nat.id by apply word.unsigned_range.
-    rewrite word.of_Z_unsigned; reflexivity.
-  Qed.
-
   Lemma In_hd {A} (d : A) (xs : list A) :
     (0 < length xs)%nat -> In (hd d xs) xs.
   Proof.
@@ -420,7 +413,8 @@ Section Proofs.
 
       (* could do reflexivity here, but it helps later if we simplify the
            expression for len *)
-      rewrite Z.land_ones, Z.mod_small; [ reflexivity |  | lia ].
+      setoid_rewrite Z.land_ones; [|lia].
+      rewrite Z.mod_small; [ reflexivity |].
       match goal with |- ?x <= ?y < ?z =>
                       change (x <= y < 2 ^ Semantics.width)
       end.

--- a/src/Rupicola/Examples/KVStore/Automated.v
+++ b/src/Rupicola/Examples/KVStore/Automated.v
@@ -353,7 +353,7 @@ Section KVSwap.
                  WeakestPrecondition.expr_body
                  WeakestPrecondition.literal
                  Semantics.interp_binop dlet.dlet].
-          destr (word.eqb (word.of_Z 1) (word.of_Z 0)); congruence. } }
+          destr (@word.eqb _ word (word.of_Z 1) (word.of_Z 0)); congruence. } }
       { rewrite word.unsigned_of_Z_0.
         split; try congruence; [ ]. intros.
         cbn [fst snd].

--- a/src/Rupicola/Examples/KVStore/Properties.v
+++ b/src/Rupicola/Examples/KVStore/Properties.v
@@ -125,7 +125,7 @@ Section Maps.
           {key_eq_dec :
              forall x y : key, BoolSpec (x = y) (x <> y) (key_eqb x y)}.
 
-  Lemma put_noop' k v m m':
+  Lemma put_noop' k v (m m' : map):
     m = m' ->
     map.get m' k = Some v ->
     m = map.put m' k v.

--- a/src/Rupicola/Examples/Loops.v
+++ b/src/Rupicola/Examples/Loops.v
@@ -15,7 +15,7 @@ Section Ex.
       (left associativity, at level 1,
        format "m [[ k  ←  v ]]").
 
-  Lemma signed_lt_unsigned w:
+  Lemma signed_lt_unsigned (w : Semantics.word):
     word.signed w <= word.unsigned w.
   Proof.
     pose proof word.unsigned_range w.
@@ -104,13 +104,13 @@ Section Ex.
                     (tok, a2)) a2 in
     (a1, a2).
   Next Obligation.
-    pose proof word.half_modulus_pos.
+    pose proof word.half_modulus_pos (word:=word).
     unfold cast, Convertible_word_nat.
     rewrite word.signed_of_Z, word.swrap_inrange in H0 by lia.
     rewrite word.signed_gz_eq_unsigned; lia.
   Qed.
   Next Obligation.
-    pose proof word.half_modulus_pos.
+    pose proof word.half_modulus_pos (word:=word).
     unfold cast, Convertible_word_nat.
     rewrite word.signed_of_Z, word.swrap_inrange in H0 by lia.
     rewrite word.signed_gz_eq_unsigned; lia.

--- a/src/Rupicola/Examples/Ttl/Ttl.v
+++ b/src/Rupicola/Examples/Ttl/Ttl.v
@@ -76,7 +76,7 @@ Section with_parameters.
                      access_size.word
                      (expr.op bopname.add
                               (expr.var vector_var)
-                              (expr.literal ((word.unsigned (word.of_Z 8) * Z.of_nat noffset))))))
+                              (expr.literal ((@word.unsigned _ Semantics.word (word.of_Z 8) * Z.of_nat noffset))))))
                k_impl)
       <{ pred (nlet_eq [var] v k) }>.
   Proof.
@@ -136,7 +136,7 @@ Section with_parameters.
       cmd.seq (cmd.store access_size.word
                          (expr.op bopname.add
                                   (expr.var vector_var)
-                                  (expr.literal ((word.unsigned (word.of_Z 8) *
+                                  (expr.literal ((@word.unsigned _ Semantics.word (word.of_Z 8) *
                                                   Z.of_nat noffset))))
                          (expr.var value_var))
               k_impl
@@ -146,7 +146,7 @@ Section with_parameters.
     unfold WordVector in *.
     repeat straightline.
     exists (word.add vector_ptr
-                     (word.of_Z (word.unsigned (word.of_Z 8) * Z.of_nat noffset))).
+                     (word.of_Z (@word.unsigned _ Semantics.word (word.of_Z 8) * Z.of_nat noffset))).
     split.
     { repeat straightline; eauto.
       exists vector_ptr; intuition.

--- a/src/Rupicola/Lib/Compiler.v
+++ b/src/Rupicola/Lib/Compiler.v
@@ -295,11 +295,11 @@ Section CompilerBasics.
   Definition compile_word_eqb :=
     unfold_id (@compile_binop_xxb _ id bopname.eq word.eqb ltac:(compile_binop_wwb_t)).
 
-  Lemma bool_word_eq_compat {T} T2w (eqb: T -> T -> bool)
+  Lemma bool_word_eq_compat {T} (T2w: T -> word) (eqb: T -> T -> bool)
         (T2w_inj: forall x y, T2w x = T2w y -> x = y)
         (eqb_compat: forall x y, eqb x y = true <-> x = y) :
     forall x y,
-      b2w (eqb x y) = (if word.eqb (T2w x) (T2w y) then word.of_Z 1 else word.of_Z 0).
+      b2w (eqb x y) = (if word.eqb (T2w x) (T2w y) then word.of_Z 1 else word.of_Z 0) :> word.
   Proof.
     intros; rewrite word.unsigned_eqb.
     destruct eqb eqn:Hb; destruct Z.eqb eqn:Hz; try reflexivity.
@@ -319,7 +319,7 @@ Section CompilerBasics.
 
   Notation cbv_beta_b2w x :=
     ltac:(pose proof x as x0;
-         change ((fun b => b2w b) ?y) with (b2w y) in (type of x0);
+         change ((fun b => b2w b) ?y) with (b2w y : word) in (type of x0);
          let t := type of x0 in exact (x: t)) (only parsing).
 
   Definition compile_bool_eqb :=

--- a/src/Rupicola/Lib/ControlFlow/DownTo.v
+++ b/src/Rupicola/Lib/ControlFlow/DownTo.v
@@ -12,6 +12,7 @@ End Gallina.
 Section Compile.
   Context {semantics : Semantics.parameters}
           {semantics_ok : Semantics.parameters_ok semantics}.
+  Implicit Types (x : Semantics.word).
 
   Lemma downto'_step {A} i count (step :A -> _) init :
     0 < i <= count ->

--- a/src/Rupicola/Lib/Loops.v
+++ b/src/Rupicola/Lib/Loops.v
@@ -949,9 +949,9 @@ Section with_parameters.
   End Loops.
 
   Section Unsigned.
-    Lemma word_unsigned_of_Z_bracketed l h w:
+    Lemma word_unsigned_of_Z_bracketed (l h : Semantics.word) w:
       word.unsigned l <= w <= word.unsigned h ->
-      word.unsigned (word.of_Z w) = w.
+      @word.unsigned _ Semantics.word (word.of_Z w) = w.
     Proof.
       pose proof word.unsigned_range l.
       pose proof word.unsigned_range h.
@@ -972,9 +972,9 @@ Section with_parameters.
   End Unsigned.
 
   Section Signed.
-    Lemma word_signed_of_Z_bracketed l h w:
+    Lemma word_signed_of_Z_bracketed (l h : Semantics.word) w:
       word.signed l <= w <= word.signed h ->
-      word.signed (word.of_Z w) = w.
+      @word.signed _ Semantics.word (word.of_Z w) = w.
     Proof.
       pose proof word.signed_range l.
       pose proof word.signed_range h.
@@ -996,7 +996,7 @@ Section with_parameters.
 
   Definition wZ_must_pos (a: Z) :
     match Z_gt_dec a 0, Z_le_dec a (2 ^ 32 - 1) with
-    | left _, left _ => word.unsigned (word.of_Z a) > 0
+    | left _, left _ => @word.unsigned _ Semantics.word (word.of_Z a) > 0
     | _, _ => True
     end.
   Proof.
@@ -1021,7 +1021,7 @@ Section with_parameters.
     Lemma lts_of_Z x y:
       - 2 ^ (Semantics.width - 1) <= x < 2 ^ (Semantics.width - 1) ->
       - 2 ^ (Semantics.width - 1) <= y < 2 ^ (Semantics.width - 1) ->
-      word.lts (word.of_Z x) (word.of_Z y) = (x <? y).
+      @word.lts _ Semantics.word (word.of_Z x) (word.of_Z y) = (x <? y).
     Proof.
       intros; rewrite word.signed_lts, !word.signed_of_Z, !word.swrap_inrange; eauto.
     Qed.
@@ -1029,19 +1029,19 @@ Section with_parameters.
     Lemma ltu_of_Z x y:
       0 <= x < 2 ^ Semantics.width ->
       0 <= y < 2 ^ Semantics.width ->
-      word.ltu (word.of_Z x) (word.of_Z y) = (x <? y).
+      @word.ltu _ Semantics.word (word.of_Z x) (word.of_Z y) = (x <? y).
     Proof.
       intros; rewrite word.unsigned_ltu, !word.unsigned_of_Z, !word.wrap_small; eauto.
     Qed.
 
-    Lemma getmany0 l t vt vx vy x y:
+    Lemma getmany0 (l : Semantics.locals) t vt vx vy x y:
       map.getmany_of_list l (vx :: vy :: vt) = Some (x :: y :: t) ->
       map.get l vx = Some x.
     Proof.
       intros; eapply (map.getmany_of_list_get _ 0); eauto || reflexivity.
     Qed.
 
-    Lemma getmany1 l t vt vx vy x y:
+    Lemma getmany1 (l : Semantics.locals) t vt vx vy x y:
       map.getmany_of_list l (vx :: vy :: vt) = Some (x :: y :: t) ->
       map.get l vy = Some y.
     Proof.

--- a/src/Rupicola/Lib/SepLocals.v
+++ b/src/Rupicola/Lib/SepLocals.v
@@ -37,12 +37,12 @@ Section Var.
     ssplit; [ | reflexivity | eassumption ].
     cbv [map.split] in *; cleanup; subst.
     ssplit; [ | eapply map.disjoint_put_l;
-                eauto using map.disjoint_empty_l ].
+                eauto using @map.disjoint_empty_l with typeclass_instances ].
     subst. rewrite map.putmany_comm by auto.
     rewrite map.put_putmany_commute.
     rewrite map.put_put_same.
     apply map.putmany_comm.
-    eapply map.disjoint_put_r; eauto using map.disjoint_empty_r.
+    eapply map.disjoint_put_r; eauto using @map.disjoint_empty_r with typeclass_instances.
   Qed.
 
   Lemma Var_put_remove l n v (R : _ -> Prop) :
@@ -54,10 +54,10 @@ Section Var.
     ssplit; [ | reflexivity | eassumption ].
     cbv [map.split] in *; cleanup; subst.
     ssplit; [ | eapply map.disjoint_put_l;
-                eauto using map.disjoint_empty_l, map.get_remove_same ].
+                eauto using @map.disjoint_empty_l, @map.get_remove_same with typeclass_instances].
     rewrite map.putmany_comm
       by (apply map.disjoint_put_l;
-          eauto using map.disjoint_empty_l, map.get_remove_same).
+          eauto using @map.disjoint_empty_l, @map.get_remove_same with typeclass_instances).
     rewrite <-map.put_putmany_commute.
     rewrite map.putmany_empty_r.
     eapply map.map_ext; intros.
@@ -72,7 +72,7 @@ Section Var.
   Proof.
     cbv [Var]; intros. do 2 eexists.
     ssplit; [ | reflexivity | eassumption ].
-    eauto using map.split_undef_put.
+    eauto using @map.split_undef_put with typeclass_instances.
   Qed.
 
   Lemma Var_exact n v :


### PR DESCRIPTION
Most of the changes are because I recently disabled typeclass-guessing for word and map instances with unknown parameters. I ported rupicola using `Implicit Types` in abstract sections and by setting implicit arguments where the parametrization was unclear to me or where the solution previously picked by typeclass search seems wrong (e.g., too specific) to me. I expect it is possible to do a much neater job than this patch (and I'd be happy to do it if you ask), but I leaned towards leaving annotations explicit for now in case this might prompt them being changed :). Guessing can also be re-enabled with `Local Hint Mode word - : typeclass_instances`.

I'll be updating fiat-crypto next, based on work that Jade already started.