### PR TITLE
use kernel names to refer to definitions in defn!

### DIFF
--- a/src/Rupicola/Lib/Notations.v
+++ b/src/Rupicola/Lib/Notations.v
@@ -448,11 +448,10 @@ Notation "defn! spec" :=
            | {| _defn_name := ?name; _defn_sig := {| _defn_args := ?args; _defn_rets := ?rets |};
                 _defn_impl := ?impl; _defn_gallina := ?gallina;
                 _defn_calls := ?calls |} =>
-              evar (body: cmd);
-              let body := eval red in body in
+              let body := open_constr:(match _ return bedrock2.Syntax.cmd with c => c end) in
               unify impl (name, (args, rets, body));
               let goal := Rupicola.Lib.Tactics.program_logic_goal_for_function impl calls in
-              exact (__rupicola_program_marker gallina -> goal)
+              exact (Rupicola.Lib.Core.__rupicola_program_marker gallina -> goal)
            end)
    end)
     (at level 0, spec custom defn_spec at level 200, only parsing).


### PR DESCRIPTION
```coq
Module Import A.
  Definition n := 42.
  Notation "'getk!'" := ltac:(exact Top.A.n).
  Notation "'getg!'" := ltac:(exact A.n).
  Notation "'getn!'" := ltac:(exact n).
  Ltac t := exact n.
  Notation "'gett!'" := ltac:(t).
  Notation "'getm!'" := (match n with v => ltac:(exact v) end).
End A.

Goal 42 = getn! . cbv. exact (@eq_refl nat 42). Qed.
Goal 42 = getg! . cbv. exact (@eq_refl nat 42). Qed.
Goal 42 = getk! . cbv. exact (@eq_refl nat 42). Qed.
Goal 42 = gett! . cbv. exact (@eq_refl nat 42). Qed.
Goal 42 = getm! . cbv. exact (@eq_refl nat 42). Qed.

Module Top.
  Module Import A.
    Definition n := 13. (* this should not affect the reference to [A.n] in "getm!" or "getn!" *)
  End A.

  Goal 42 = gett! . cbv. exact (@eq_refl nat 42). Qed.
  Goal 42 = getm! . cbv. exact (@eq_refl nat 42). Qed.
  Goal 42 = getk! . cbv. exact (@eq_refl nat 42). Qed.

  Goal 42 = getg! . cbv. exact (@eq_refl nat 42). Qed.
  (* The term "eq_refl" has type "42 = 42" while it is expected to have type "42 = 13". *)

  Goal 42 = getn! . cbv. exact (@eq_refl nat 42). Qed.
  (* The term "eq_refl" has type "42 = 42" while it is expected to have type "42 = 13". *)
End Top.
```