### PR TITLE
Add back submodules dependabot, on monthly basis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
-#  - package-ecosystem: "gitsubmodule"
-#    directory: "/"
-#    schedule:
-#      interval: "daily"
-#    labels:
-#      - "submodules"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "yearly"
+    labels:
+      - "submodules"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,6 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "yearly"
+      interval: "monthly"
     labels:
       - "submodules"


### PR DESCRIPTION
Hopefully this will not be too annoying; monthly is the least frequent
that dependabot allows according to
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval

I mostly want to be able to trigger submodules updates from
https://github.com/mit-plv/rupicola/network/updates and use the
auto-merge feature.

Thoughts @samuelgruetter and others?  (This mostly inspired by me having to open up terminal to deal with https://github.com/coq/coq/pull/16130#issuecomment-1153190087)