### PR TITLE
Check for submodule updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,6 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
     labels:
       - "submodules"


### PR DESCRIPTION
This may ease maintenance of updates for Coq CI.  But it will also make the repo more noisy.  Do we want this?