### PR TITLE
[CI] add coq-check-all job

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -63,3 +63,15 @@ jobs:
       run: make -j2 deps
     - name: make all
       run: make -j2 all
+
+  coq-check-all:
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+    - run: echo 'build passed'
+      if: ${{ needs.build.result == 'success' }}
+    - run: echo 'build failed' && false
+      if: ${{ needs.build.result != 'success' }}
+    - run: echo 'test-standalone failed' && false
+      if: ${{ needs.test-standalone.result != 'success' }}

--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -73,5 +73,3 @@ jobs:
       if: ${{ needs.build.result == 'success' }}
     - run: echo 'build failed' && false
       if: ${{ needs.build.result != 'success' }}
-    - run: echo 'test-standalone failed' && false
-      if: ${{ needs.test-standalone.result != 'success' }}


### PR DESCRIPTION
This allows branch protection (for automerge) that doesn't need to evolve as tested Coq versions change (just make the only required check be coq-check-all)