### PR TITLE
Create dependabot-automerge.yml

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,18 @@
+name: Dependabot Automerge
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  dependabot-automerge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    env:
+      PR_URL: ${{github.event.pull_request.html_url}}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      #- name: approve
+      #  run: gh pr review --approve "$PR_URL"
+      - name: merge
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
This works for Fiat Crypto https://github.com/mit-plv/fiat-crypto/pull/1862#issuecomment-2053682801, but note that you'll want to merge https://github.com/mit-plv/rupicola/pull/112 and branch protect with coq-check-all first. 

Also note that this only triggers on dependabot actions, so if you click the rebase button on a dependabot PR rather than commenting `@dependabot rebase`, it won't trigger.  (But that's probably fine, since it'll hopefully already be set to automerge)