### PR TITLE
Add a copy of assuming_correctness_of_in

### DIFF
--- a/src/Rupicola/Lib/Tactics.v
+++ b/src/Rupicola/Lib/Tactics.v
@@ -207,6 +207,13 @@ Ltac straightline_map_solver :=
 
 Ltac straightline' := straightline_plus ltac:(solve [straightline_map_solver]).
 
+Ltac assuming_correctness_of_in callees functions P :=
+  lazymatch callees with
+  | nil => P
+  | cons ?f ?callees =>
+    let f_spec := lazymatch constr:(_:spec_of f) with ?x => x end in
+    constr:(f_spec functions -> ltac:(let t := assuming_correctness_of_in callees functions P in exact t))
+  end.
 
 (* modified version of program_logic_goal_for_function, in which callee names
   are manually inserted *)


### PR DESCRIPTION
Rupicola has a duplicated version of the
Program_logic_goal_for_function tactic which was depending on the tactic assuming_correctness_of_in.

I am refactoring these tactics in bedrock2. In order to do this easily, decouple the dependency in rupicola, the tactic it relied on should probably not have been exposed in this way by bedrock anyways, as it looks like an implementation detail and not something that should be public API.

To avoid duplication in the future, one could add the different way to create program logic goals to bedrock2, and remove assuming_correctness_of_in and program_logic_goal_for_function from rupicola.