### PR TITLE
Use ecancel_assumption_impl

### DIFF
--- a/src/Rupicola/Lib/Tactics.v
+++ b/src/Rupicola/Lib/Tactics.v
@@ -43,8 +43,8 @@ Ltac handle_call :=
   straightline_call;
   [ ssplit;
     lazymatch goal with
-    | |- sep _ _ _ => ecancel_assumption
-    | |- exists R, sep _ R _ => eexists; ecancel_assumption
+    | |- sep _ _ _ => ecancel_assumption_impl
+    | |- exists R, sep _ R _ => eexists; ecancel_assumption_impl
     | _ => idtac
     end
   | cbv [postcondition_func postcondition_func_norets] in *;


### PR DESCRIPTION
Using the impl version instead of the normal one allows to use implications such as (FElem px x) -> (Placeholder px _).

This will be needed in a subsequent change in fiat crypto to use Placeholder (with map.of_list_word_at) instead of
FElem in field operations.