### PR TITLE
Adapt rupicola to word size refactoring

### DIFF
--- a/src/Rupicola/Examples/Arithmetic.v
+++ b/src/Rupicola/Examples/Arithmetic.v
@@ -1,25 +1,20 @@
 Require Import Rupicola.Lib.Api.
 Require Import Rupicola.Lib.Arrays.
 Require Import Rupicola.Lib.Loops.
-From bedrock2 Require BasicC32Semantics BasicC64Semantics.
+From coqutil Require Bitwidth32 Bitwidth64.
+From bedrock2 Require Import BasicCSemantics.
+Require bedrock2.BasicC32Semantics bedrock2.BasicC64Semantics.
 
 Module Type FNV1A_params.
-  Parameter (width: Z) (BW: Bitwidth width) (word: word.word width) (mem: map.map word Byte.byte).
-  Existing Instance BW.
-  Existing Instance word.
-  Existing Instance mem.
-  Parameter locals: map.map String.string word.
-  Parameter ext_spec: bedrock2.Semantics.ExtSpec.
-  Parameter (wordok : word.ok word) (mapok : map.ok mem).
-  Parameter localsok : map.ok locals.
-  Parameter ext_spec_ok : Semantics.ext_spec.ok ext_spec.
+  Parameter (width: Z) (BW: Bitwidth width).
+  Notation word := (Naive.word width).
   Parameter prime : word.
   Parameter offset : word.
 End FNV1A_params.
 
 Module FNV1A (Import P: FNV1A_params).
-#[global]
-  Existing Instances BW word locals mem ext_spec wordok mapok localsok ext_spec_ok.
+  #[global]
+  Existing Instances BW.
   Import SizedListArrayCompiler.
 
   Definition update (hash data : word) :=
@@ -28,7 +23,6 @@ Module FNV1A (Import P: FNV1A_params).
     let/n hash := word.mul hash p in
     hash.
 
-  Implicit Type R : mem -> Prop.
 #[global]
   Instance spec_of_update : spec_of "update" :=
     fnspec! "update" (hash: word) (data: word) ~> hash',
@@ -111,7 +105,6 @@ Module Murmur3.
     let/n k := word.mul k (word.of_Z 461845907) in
     k.
 
-  Implicit Type R : mem -> Prop.
 #[global]
   Instance spec_of_scramble : spec_of "scramble" :=
     fnspec! "scramble" (k: word) ~> k',

--- a/src/Rupicola/Examples/CapitalizeThird/Properties.v
+++ b/src/Rupicola/Examples/CapitalizeThird/Properties.v
@@ -48,7 +48,7 @@ Section Generalizable.
     right; congruence.
   Qed.
 
-  Lemma only_differ_get (locals : locals) vars locals' v post :
+  Lemma only_differ_get (locals : @map.rep string word locals) vars locals' v post :
     map.only_differ locals vars locals' ->
     ~ vars v ->
     WeakestPrecondition.get locals v post ->
@@ -274,7 +274,7 @@ Section Proofs.
       apply iff1_sep_cancel.
       eapply @array_index_nat_inbounds
         with (n:=n) (default:=byte.of_Z 0);
-        eauto using wordok, mapok.
+        eauto; try typeclasses eauto.
       lia. }
     rewrite word.ring_morph_mul, !word.of_Z_unsigned.
     (* annoying separation-logic algebra *)
@@ -358,7 +358,7 @@ Section Proofs.
       split; [ cbn; right; reflexivity | ]. (* only_differ *)
       do 2 (eexists; split; [ reflexivity | ]). (* fetch i and c_ptr *)
       split; [ reflexivity | ]. (* measure = len s - i *)
-      split; [ cbn; rewrite word.unsigned_of_Z_0; lia | ]. (* i <= len s *)
+      split; [ cbn; lia | ]. (* i <= len s *)
 
       (* c_ptr = s_ptr + wordsize + i * charsize *)
       split.
@@ -398,7 +398,6 @@ Section Proofs.
 
       (* fetch the value of "len" from the start-of-loop locals *)
       cbv [WeakestPrecondition.get].
-      cbn.
       eexists; split; [ reflexivity | ].
 
       (* could do reflexivity here, but it helps later if we simplify the
@@ -410,6 +409,7 @@ Section Proofs.
       end.
       apply word.unsigned_range. }
 
+    cbv [Semantics.interp_binop].
     (* prove continue/break case depending on value of loop condition *)
     match goal with |- context [if ?x then _ else _] => destr x end;
       split; try (let X := fresh in intro X; cbv in X; congruence); [ | ].

--- a/src/Rupicola/Lib/Invariants.v
+++ b/src/Rupicola/Lib/Invariants.v
@@ -60,7 +60,7 @@ Ltac infer_word_instance locals :=
   lazymatch type of locals with
   | map.rep (map := ?ls) =>
     lazymatch type of ls with
-    | map.map _ (word.rep (word := ?W)) => constr:(W)
+    | context [(word.rep (word := ?W))] => constr:(W)
     end
   end.
 


### PR DESCRIPTION
To be merged with https://github.com/mit-plv/bedrock2/pull/551.
This change adapts rupicola to word size refactorings.