### PR TITLE
Support Rocq 9.0 minimum, update CI, and bump bedrock2

### DIFF
--- a/.github/workflows/coq-docker.yml
+++ b/.github/workflows/coq-docker.yml
@@ -16,6 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        - env: { COQ_VERSION: "9.0", DOCKER_COQ_VERSION: "9.0" }
+          os: 'ubuntu-latest'
+        - env: { COQ_VERSION: "9.1", DOCKER_COQ_VERSION: "9.1" }
+          os: 'ubuntu-latest'
+        - env: { COQ_VERSION: "9.2", DOCKER_COQ_VERSION: "9.2" }
+          os: 'ubuntu-latest'
         - env: { COQ_VERSION: "master", DOCKER_COQ_VERSION: "dev" }
           os: 'ubuntu-latest'
 
@@ -40,4 +46,4 @@ jobs:
       uses: coq-community/docker-coq-action@v1
       with:
         coq_version: ${{ matrix.env.DOCKER_COQ_VERSION }}
-        custom_script: sudo make install COQBIN="$(dirname "$(which coqc)")/"
+        custom_script: sudo make install COQBIN="$(dirname "$(which rocq)")/"

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -43,7 +43,7 @@ jobs:
         sudo mount proc /chroot/proc -t proc
         sudo mount sysfs /chroot/sys -t sysfs
         sudo chroot /chroot apt-get -q -y -o Acquire::Retries=30 install apt-eatmydata
-        sudo chroot /chroot apt-get -q -y -o Acquire::Retries=30 install sudo git make time coq libcoq-stdlib
+        sudo chroot /chroot apt-get -q -y -o Acquire::Retries=30 install sudo git make time coq libcoq-stdlib libcoq-core-ocaml-dev
         sudo chroot /chroot groupadd -g "$(id -g)" "$(id -g -n)"
         sudo chroot /chroot useradd  -g "$(id -g)" -u "$(id -u)" "$(id -u -n)"
         printf "%s ALL=(ALL) NOPASSWD: ALL\n" "$(id -u -n)" | sudo tee /chroot/etc/sudoers.d/root

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lib: Makefile.coq.lib $(VS_LIB)
 	rm -f .coqdeps.d
 	$(MAKE) -f Makefile.coq.lib
 
-COQ_MAKEFILE := $(COQBIN)coq_makefile -f _CoqProject INSTALLDEFAULTROOT = Rupicola $(COQMF_ARGS)
+COQ_MAKEFILE := "$(COQBIN)rocq" makefile -f _CoqProject INSTALLDEFAULTROOT = Rupicola $(COQMF_ARGS)
 
 force:
 

--- a/src/Rupicola/Examples/Net/IPChecksum/ubench_ocaml.sh
+++ b/src/Rupicola/Examples/Net/IPChecksum/ubench_ocaml.sh
@@ -3,7 +3,7 @@ set -eu
 cd "$(dirname "$0")"
 
 ( cd ../../../../../
-  coqc ${COQFLAGS:-$(make -f Makefile.coqflags)} src/Rupicola/Examples/Net/IPChecksum/SpecExtraction.v
+  "${COQBIN}rocq" compile ${COQFLAGS:-$(make -f Makefile.coqflags)} src/Rupicola/Examples/Net/IPChecksum/SpecExtraction.v
 ) > ip_checksum_ocaml.ml
 
 CC="${CC:-cc}"


### PR DESCRIPTION
Transition build system and CI to Rocq 9.0 minimum.

- Update Makefile and ubench_ocaml.sh to invoke rocq directly.
- Add Rocq 9.0, 9.1, 9.2, and master to Docker CI matrix.
- Update Debian and Alpine CI dependencies to rocq.
- Bump bedrock2 submodule to merged Rocq 9.0 compatibility commit.

Co-authored-by: Miriam Polzer <mpolzer@google.com>